### PR TITLE
Altering scrolltop of objects targeted by ToC so not to appear too high.

### DIFF
--- a/js/behavior.js
+++ b/js/behavior.js
@@ -1,4 +1,11 @@
 $(function() {
+
+	$('#page-contents a').click(function(e){
+		e.preventDefault();
+		var $target = $(this).attr('href');
+		$(document).scrollTop( $($target).offset().top-100 );                                                                                                                                                                                                     
+	});
+
 	$('#subnav-select').on('change', function() {
 		document.location = $(this).find('option:selected').val();
 	});


### PR DESCRIPTION
The links in the table of contents where carrying the heading up and under the menu bar. This fix adjusts the scrollTop to that the anchor functionality works as expected.
