### PR TITLE
Changed deprecated function wfMsg to wfMessage in BootstrapMediaWiki.…

### DIFF
--- a/BootstrapMediaWiki.skin.php
+++ b/BootstrapMediaWiki.skin.php
@@ -467,7 +467,7 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 			// get the text as static wiki text, but with already expanded templates,
 			// which also e.g. to use {{#dpl}} (DPL third party extension) for dynamic menus.
 		    /* $parserOutput = $wgParser->preprocess($article->getRawText(), $pageTitle, $wgParserOptions );*/
-		    $parserOutput = $wgParser->preprocess($article->getPage()->getContent(Revision::RAW), $pageTitle, $wgParserOptions );
+		    $parserOutput = $wgParser->preprocess(ContentHandler::getContentText($article->getPage()->getRevision()->getContent(Revision::RAW)), $pageTitle, $wgParserOptions );
 			return $parserOutput;
 		}
 	}
@@ -480,7 +480,7 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 		} else {
 			$article = new Article($pageTitle);
 			$wgParserOptions = new ParserOptions($wgUser);
-			$parserOutput = $wgParser->parse($article->getPage()->getContent(Revision::RAW), $pageTitle, $wgParserOptions);
+		    $parserOutput = $wgParser->parse(ContentHandler::getContentText($article->getPage()->getRevision()->getContent(Revision::RAW)), $pageTitle, $wgParserOptions);
 			echo $parserOutput->getText();
 		}
 	}

--- a/BootstrapMediaWiki.skin.php
+++ b/BootstrapMediaWiki.skin.php
@@ -144,7 +144,7 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 						?>
 						<ul class="nav navbar-nav navbar-right">
 							<li>
-							<?php echo Linker::linkKnown( SpecialPage::getTitleFor( 'Userlogin' ), wfMsg( 'login' ) ); ?>
+							<?php echo Linker::linkKnown( SpecialPage::getTitleFor( 'Userlogin' ), wfMessage( 'login' ) ); ?>
 							</li>
 						</ul>
 						<?php

--- a/BootstrapMediaWiki.skin.php
+++ b/BootstrapMediaWiki.skin.php
@@ -467,7 +467,7 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 			// get the text as static wiki text, but with already expanded templates,
 			// which also e.g. to use {{#dpl}} (DPL third party extension) for dynamic menus.
 		    /* $parserOutput = $wgParser->preprocess($article->getRawText(), $pageTitle, $wgParserOptions );*/
-		    $parserOutput = $wgParser->preprocess($article->getContent(Revision::RAW), $pageTitle, $wgParserOptions );
+		    $parserOutput = $wgParser->preprocess($article->getPage()->getContent(Revision::RAW), $pageTitle, $wgParserOptions );
 			return $parserOutput;
 		}
 	}
@@ -480,7 +480,7 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 		} else {
 			$article = new Article($pageTitle);
 			$wgParserOptions = new ParserOptions($wgUser);
-			$parserOutput = $wgParser->parse($article->getContent(Revision::RAW), $pageTitle, $wgParserOptions);
+			$parserOutput = $wgParser->parse($article->getPage()->getContent(Revision::RAW), $pageTitle, $wgParserOptions);
 			echo $parserOutput->getText();
 		}
 	}

--- a/BootstrapMediaWiki.skin.php
+++ b/BootstrapMediaWiki.skin.php
@@ -466,7 +466,8 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 			$wgParserOptions = new ParserOptions($wgUser);
 			// get the text as static wiki text, but with already expanded templates,
 			// which also e.g. to use {{#dpl}} (DPL third party extension) for dynamic menus.
-			$parserOutput = $wgParser->preprocess($article->getRawText(), $pageTitle, $wgParserOptions );
+		    /* $parserOutput = $wgParser->preprocess($article->getRawText(), $pageTitle, $wgParserOptions );*/
+		    $parserOutput = $wgParser->preprocess($article->getContent(Revision::RAW), $pageTitle, $wgParserOptions );
 			return $parserOutput;
 		}
 	}
@@ -479,7 +480,7 @@ class BootstrapMediaWikiTemplate extends QuickTemplate {
 		} else {
 			$article = new Article($pageTitle);
 			$wgParserOptions = new ParserOptions($wgUser);
-			$parserOutput = $wgParser->parse($article->getRawText(), $pageTitle, $wgParserOptions);
+			$parserOutput = $wgParser->parse($article->getContent(Revision::RAW), $pageTitle, $wgParserOptions);
 			echo $parserOutput->getText();
 		}
 	}


### PR DESCRIPTION
The deprecated frunction was removed in new mediawiki so the page couldn't render.
This fixes the issue.